### PR TITLE
Add model watch option

### DIFF
--- a/wandb_allennlp/training/callbacks/log_to_wandb.py
+++ b/wandb_allennlp/training/callbacks/log_to_wandb.py
@@ -25,8 +25,7 @@ if allennlp_version_major >= 1:
                 self,
                 epoch_end_log_freq: int = 1,
                 watch_model: bool = False,
-                watch_log_freq: int = 1000,
-                trainer: GradientDescentTrainer = None
+                watch_log_freq: int = 1000
         ) -> None:
             # import wandb here to be sure that it was initialized
             # before this line was executed

--- a/wandb_allennlp/training/callbacks/log_to_wandb.py
+++ b/wandb_allennlp/training/callbacks/log_to_wandb.py
@@ -24,6 +24,8 @@ if allennlp_version_major >= 1:
         def __init__(
                 self,
                 epoch_end_log_freq: int = 1,
+                watch_model = False,
+                trainer: GradientDescentTrainer = None
         ) -> None:
             # import wandb here to be sure that it was initialized
             # before this line was executed
@@ -37,6 +39,9 @@ if allennlp_version_major >= 1:
             self.current_batch_num = -1
             self.current_epoch_num = -1
             self.previous_logged_epoch = -1
+
+            if watch_model and trainer is not None:
+                self.wandb.watch(trainer.model)
 
         def update_config(self, trainer: GradientDescentTrainer) -> None:
             if self.config is None:

--- a/wandb_allennlp/training/callbacks/log_to_wandb.py
+++ b/wandb_allennlp/training/callbacks/log_to_wandb.py
@@ -24,7 +24,8 @@ if allennlp_version_major >= 1:
         def __init__(
                 self,
                 epoch_end_log_freq: int = 1,
-                watch_model = False,
+                watch_model: bool = False,
+                watch_log_freq: int = 1000,
                 trainer: GradientDescentTrainer = None
         ) -> None:
             # import wandb here to be sure that it was initialized
@@ -40,8 +41,9 @@ if allennlp_version_major >= 1:
             self.current_epoch_num = -1
             self.previous_logged_epoch = -1
 
-            if watch_model and trainer is not None:
-                self.wandb.watch(trainer.model)
+            self.watch_log_freq = watch_log_freq
+            self.watch_model = watch_model
+            self.is_watching = False
 
         def update_config(self, trainer: GradientDescentTrainer) -> None:
             if self.config is None:
@@ -66,6 +68,11 @@ if allennlp_version_major >= 1:
 
             if is_master and (self.config is None):
                 self.update_config(trainer)
+
+            if self.watch_model and not self.is_watching:
+                logger.info("Watching trainer model with wandb")
+                self.wandb.watch(trainer.model, log_freq=self.watch_log_freq)
+                self.is_watching = True
 
             self.current_epoch_num += 1
 


### PR DESCRIPTION
Added the ability to "watch" the allennlp model using the `wand.watch()` interface. It works through the same callback that the basic scenario uses.