### PR TITLE
add support for AllenNLP 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+wandb_allennlp/tests/wandb/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ trainer: {
 ...
 ```
 
+For allennlp v2.x :
+
+```
+...
+
+trainer: {
+    callbacks: [
+      ...,
+
+      {
+        type: 'log_metrics_to_wandb',
+      },
+
+      ...,
+    ],
+    ...,
+}
+...
+...
+```
+
 2. Execute the following command instead of `allennlp train`:
 
 ```
@@ -244,7 +265,7 @@ local int_value = std.parseJson(std.extVar('int_value'));
   ...
   trainer: {
     ...
-    epoch_callbacks: ['log_metrics_to_wandb'],
+    callbacks: ['log_metrics_to_wandb'],
   },
 }
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -58,6 +58,26 @@ trainer: {
 ...
 ```
 
+**and the following for allennlp v2.x :**
+```
+...
+
+trainer: {
+    callbacks: [
+      ...,
+      
+      {
+        type: 'log_metrics_to_wandb',
+      },
+      
+      ...,
+    ],
+    ...,
+}
+...
+...
+```
+
 3. Create a sweep config file. See [sweep_configs/pair_classification/decomposable_attention.yaml](examples/sweep_configs/pair_classification/decomposable_attention.yaml) for the example config.
 
 4. Create the sweep.

--- a/examples/training_configs/pair_classification/decomposable_attention.jsonnet
+++ b/examples/training_configs/pair_classification/decomposable_attention.jsonnet
@@ -73,6 +73,6 @@
     optimizer: {
       type: 'adagrad',
     },
-    epoch_callbacks: [{ type: 'log_metrics_to_wandb' }],  //  The only extra line in the config!!!
+    callbacks: [{ type: 'log_metrics_to_wandb' }],  //  The only extra line in the config!!!
   },
 }

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ script_launch_mode = subprocess
 
 [tox]
 # check: https://tox.readthedocs.io/en/latest/config.html#generating-environments-conditional-settings
-envlist = py{36,37,38,py3}-allennlp{0.9.0,1.0.0},lint
+envlist = py{36,37,38,39,py3}-allennlp{0.9.0,1.0.0,1.4.0,2.0.0},lint
 
 [testenv]
 passenv = WANDB_API_KEY
@@ -15,6 +15,8 @@ deps =
     allennlp0.9.0: allennlp==0.9.0
     allennlp1.0.0: allennlp==1.0.0
     allennlp1.0.0: allennlp-models==1.0.0
+    allennlp1.4.0: allennlp-models==1.4.0
+    allennlp2.0.0: allennlp-models==2.0.0
 
 changedir={toxinidir}/wandb_allennlp/tests
 commands =

--- a/wandb_allennlp/tests/configs/dummy_v2.0.jsonnet
+++ b/wandb_allennlp/tests/configs/dummy_v2.0.jsonnet
@@ -1,0 +1,34 @@
+local data_path = std.extVar('DATA_PATH');
+{
+  dataset_reader: {
+    type: 'snli',
+    token_indexers: {
+      tokens: {
+        type: 'single_id',
+        lowercase_tokens: true,
+      },
+    },
+  },
+  train_data_path: data_path + '/snli_1.0_test/snli_1.0_train.jsonl',
+  validation_data_path: data_path + '/snli_1.0_test/snli_1.0_dev.jsonl',
+  model: {
+    type: 'dummy',
+    a: 50,
+  },
+  data_loader: {
+    batch_sampler: {
+      type: 'bucket',
+      batch_size: 64,
+    },
+  },
+  trainer: {
+    optimizer: {
+      type: 'adam',
+      lr: 0.001,
+      weight_decay: 0.0,
+    },
+    cuda_device: -1,
+    num_epochs: 2,
+    callbacks: ['log_metrics_to_wandb'],
+  },
+}

--- a/wandb_allennlp/tests/configs/parameter_tying_v2.0.jsonnet
+++ b/wandb_allennlp/tests/configs/parameter_tying_v2.0.jsonnet
@@ -1,0 +1,43 @@
+local data_path = std.extVar('DATA_PATH');
+local a = std.parseJson(std.extVar('a'));
+local bool_value = std.parseJson(std.extVar('bool_value'));
+local int_value = std.parseJson(std.extVar('int_value'));
+{
+  dataset_reader: {
+    type: 'snli',
+    token_indexers: {
+      tokens: {
+        type: 'single_id',
+        lowercase_tokens: true,
+      },
+    },
+  },
+  train_data_path: data_path + '/snli_1.0_test/snli_1.0_train.jsonl',
+  validation_data_path: data_path + '/snli_1.0_test/snli_1.0_dev.jsonl',
+  model: {
+    type: 'parameter-tying',
+    a: a,
+    b: a,
+    bool_value: bool_value,
+    bool_value_not: !bool_value,
+    int_value: int_value,
+    int_value_10: int_value + 10,
+
+  },
+  data_loader: {
+    batch_sampler: {
+      type: 'bucket',
+      batch_size: 64,
+    },
+  },
+  trainer: {
+    optimizer: {
+      type: 'adam',
+      lr: 0.001,
+      weight_decay: 0.0,
+    },
+    cuda_device: -1,
+    num_epochs: 2,
+    callbacks: ['log_metrics_to_wandb'],
+  },
+}

--- a/wandb_allennlp/tests/dummy_sweep_v2.0.yaml
+++ b/wandb_allennlp/tests/dummy_sweep_v2.0.yaml
@@ -1,0 +1,20 @@
+name: dummy_test_console_script_v2.0
+program: wandb_allennlp
+command:
+  - ${program} #omit the interpreter as we use allennlp train command directly
+  - "--subcommand=train"
+  - "--include-package=models" # add all packages containing your registered classes here
+  - "--include-package=allennlp_models"
+  - "--config_file=configs/dummy_v2.0.jsonnet"
+  - ${args}
+method: bayes
+metric:
+  name: training_loss
+  goal: minimize
+parameters:
+  # hyperparameters start with overrides
+  # Ranges
+  model.a:
+    min: 1
+    max: 10
+    distribution: uniform

--- a/wandb_allennlp/tests/parameter-tying_sweep_v2.0.yaml
+++ b/wandb_allennlp/tests/parameter-tying_sweep_v2.0.yaml
@@ -1,0 +1,25 @@
+name: parameter_tying_test_console_script_v2.0
+program: wandb_allennlp
+command:
+  - ${program} #omit the interpreter as we use allennlp train command directly
+  - "--subcommand=train"
+  - "--include-package=models" # add all packages containing your registered classes here
+  - "--include-package=allennlp_models"
+  - "--config_file=configs/parameter_tying_v2.0.jsonnet"
+  - ${args}
+method: bayes
+metric:
+  name: training_loss
+  goal: minimize
+parameters:
+  # hyperparameters start with overrides
+  # Ranges
+  # Add env. to tell that it is a top level parameter
+  env.a:
+    min: 1
+    max: 10
+    distribution: uniform
+  env.bool_value:
+    values: [true, false]
+  env.int_value:
+    values: [-1, 0, 1, 10]

--- a/wandb_allennlp/tests/test_sweep.py
+++ b/wandb_allennlp/tests/test_sweep.py
@@ -7,9 +7,15 @@ def test_sweep(script_runner):
     if major < 1 and minor >= 9:
         ret = script_runner.run('wandb', 'agent', '--count=1',
                                 'dhruveshpate/wandb_allennlp_test/p285xdjw')
-    else:
+    elif major < 2:
         ret = script_runner.run(
             'wandb', 'agent', '--count=1',
+            'dhruveshpate/wandb-allennlp-wandb_allennlp_tests/ueh5q858')
+    else:
+        # tests for version 2.x
+        ret = script_runner.run(
+            'wandb', 'agent', '--count=1',
+            # FIXME: needs new sweep with 2.0?
             'dhruveshpate/wandb-allennlp-wandb_allennlp_tests/ueh5q858')
 
     assert ret.success
@@ -22,6 +28,12 @@ def test_parameter_tying(script_runner):
     if major >=1:
         ret = script_runner.run(
             'wandb', 'agent', '--count=1',
+            'dhruveshpate/wandb-allennlp-wandb_allennlp_tests/cwwdov66')
+    else:
+        # tests for version 2.x
+        ret = script_runner.run(
+            'wandb', 'agent', '--count=1',
+            # FIXME: needs new sweep with 2.0?
             'dhruveshpate/wandb-allennlp-wandb_allennlp_tests/cwwdov66')
 
         assert ret.success


### PR DESCRIPTION
This maybe needs new sweeps in test_dummy.py
My tests with my account and with 2.0-configs were successful.
There is some code duplication but for the sake of readability between different AllenNLP versions I didn't changed that.

I used Python 3.9 and AllenNLP 1.4 before, so I added it to tox.