### PR TITLE
For bump versions

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -1,13 +1,13 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
+---
 name: Tests for pull requests and pushes on master
 
 on:
   push:
-    branches: [ master, develop/master ]
+    branches: [master, develop/master]
   pull_request:
-    branches: [ master, develop/master ]
+    branches: [master, develop/master]
 
 jobs:
   build:
@@ -20,26 +20,26 @@ jobs:
     env:
       TOXENV: allennlp${{ matrix.allennlp-version }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Cache pip
-      id: cache
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip # This path is specific to Ubuntu
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-${{ matrix.allennlp-version }}-pip-${{ hashFiles('setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.allennlp-version }}-pip-
-          ${{ runner.os }}-
-    - name: Install Tox and any other packages
-      run: pip install tox
-    - name: Run test using Tox for allennlp==${{ matrix.allennlp-version }}
-      shell: bash
-      env:
-        WANDB_API_KEY : ${{secrets.WANDB_API_KEY}}
-      run: tox
-        #run: tox -e py
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip  # This path is specific to Ubuntu
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-${{ matrix.allennlp-version }}-pip-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.allennlp-version }}-pip-
+            ${{ runner.os }}-
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run test using Tox for allennlp==${{ matrix.allennlp-version }}
+        shell: bash
+        env:
+          WANDB_API_KEY: ${{secrets.WANDB_API_KEY}}
+        run: tox
+        # run: tox -e py

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
-        allennlp-version: ["2.5.0", "2.8.0", "2.9.0"]
+        python-version: ["3.8", "3.9"]
+        allennlp-version: ["2.5.0", "2.8.0", "2.9.3"]
     env:
       TOXENV: allennlp${{ matrix.allennlp-version }}
     steps:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ install_requires = [
     "tensorboard",
     "overrides",
     "shortuuid",
-    "nltk<3.6.6" # remove this once the support for older versions of ALLENNLP is dropped.
+    # allennlp 2.9+ needs a newer version - this may break older versions
+    # "nltk<3.6.6" # remove this once the support for older versions of ALLENNLP is dropped.
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 install_requires = [
-    "allennlp>=2.5.0,<=2.9.0",
-    "wandb>=0.10.11,<=0.12.10",
+    "allennlp>=2.5.0,<2.10.0",
+    "wandb>=0.10.11,<=0.12.15",
     "pyyaml",
     "tensorboard",
     "overrides",
@@ -15,7 +15,7 @@ install_requires = [
 
 setup(
     name="wandb_allennlp",
-    version="0.3.1",
+    version="0.3.2",
     author="Dhruvesh Patel",
     author_email="1793dnp@gmail.com",
     description="Utilities to use allennlp with wandb",

--- a/src/wandb_allennlp/__init__.py
+++ b/src/wandb_allennlp/__init__.py
@@ -3,4 +3,4 @@ import wandb_allennlp.commands
 import wandb_allennlp.training
 import os
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ script_launch_mode = subprocess
 
 [tox]
 # check: https://tox.readthedocs.io/en/latest/config.html#generating-environments-conditional-settings
-envlist = py{37,38,39,py3}-allennlp{2.5.0,2.8.0,2.9.0},lint
+envlist = py{37,38,39,py3}-allennlp{2.5.0,2.8.0,2.9.3},lint
 
 [testenv]
 passenv = WANDB_API_KEY
@@ -16,8 +16,8 @@ deps =
     allennlp2.5.0: wandb==0.10.11
     allennlp2.8.0: allennlp==2.8.0
     allennlp2.8.0: wandb==0.12.10
-    allennlp2.9.0: allennlp==2.9.0
-    allennlp2.9.0: wandb==0.12.10
+    allennlp2.9.3: allennlp==2.9.3
+    allennlp2.9.3: wandb==0.12.15
 
 changedir={toxinidir}/tests
 # based the nltk download is based on https://github.com/allenai/allennlp/pull/5540/files

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ changedir={toxinidir}/tests
 # based the nltk download is based on https://github.com/allenai/allennlp/pull/5540/files
 # it can be removed after the support for older versions of allennlp is dropped.
 commands =
-    python -c 'import nltk; [nltk.download(p) for p in ("wordnet", "wordnet_ic", "sentiwordnet", "omw")]'
+    python -c 'import nltk; [nltk.download(p) for p in ("wordnet", "wordnet_ic", "sentiwordnet", "omw", "omw-1.4")]'
     pytest
 
 [testenv:lint]


### PR DESCRIPTION
For running tests on changes in PR https://github.com/dhruvdcoder/wandb-allennlp/pull/34

1. [bump versions of allennlp to 2.9.3 and wandb to 0.12.15](https://github.com/dhruvdcoder/wandb-allennlp/pull/34/commits/a8f6b5dacc39189a8280bcd1843b3e29fd1e271f)
2. Remove pinning of nltk.